### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,9 @@
 This subrepository holds the source for various packages and tools that support
 development of the Go programming language.
 
-To submit changes to this repository, see http://golang.org/doc/contribute.html.
+To submit changes to this repository, see https://golang.org/doc/contribute.html.
 
-app/: a.k.a the "dashboard"; the App Engine code that runs http://build.golang.org/
+app/: a.k.a the "dashboard"; the App Engine code that runs https://build.golang.org/
 
 cmd/:
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://build.golang.org/ | https://build.golang.org/ 
http://golang.org/doc/contribute.html | https://golang.org/doc/contribute.html 
